### PR TITLE
Fix mixed content error while using https

### DIFF
--- a/src/main/ui/src/services/ApiConfig.js
+++ b/src/main/ui/src/services/ApiConfig.js
@@ -1,6 +1,6 @@
 /*eslint no-undef: "off"*/
 const local = process.env.REACT_APP_ENV === 'local';
-const baseWs = local? process.env.REACT_APP_LOCAL_SPRING_WS : `ws://${window.location.hostname}:${window.location.port}`;
+const baseWs = local? process.env.REACT_APP_LOCAL_SPRING_WS : `${window.location.protocol === 'https:' ? 'wss:' : 'ws:' }//${window.location.hostname}:${window.location.port}`;
 const baseUrl = local? process.env.REACT_APP_LOCAL_SPRING_API : `${window.location.protocol}//${window.location.hostname}:${window.location.port}`;
 const baseRestApi = baseUrl + "/api";
 const baseWebSocket = baseWs + "/ws";


### PR DESCRIPTION
Fixed issue when solution is deployed behind https

```
Mixed Content: The page at '<URL>' was loaded over HTTPS, but attempted to connect to the insecure WebSocket endpoint
```